### PR TITLE
add key sever

### DIFF
--- a/templates/en/download.html
+++ b/templates/en/download.html
@@ -25,7 +25,7 @@
         <p>You can easily verufy that the image you downloaded is valid and authentic:</p>
         <ul>
             <li><strong>Download our public GPG key:</strong></li>
-            <p><code>gpg --search-key 364B68D4</code></p>
+            <p><code>gpg  --keyserver hkp://pgp.mit.edu --search-key 364B68D4</code></p>
                 
             <li><strong>Verifying the key fingerprint:</strong></li>
             <p><em>Make sure you downloaded a genuine copy of our GPG key</em></p>

--- a/templates/en/download.html
+++ b/templates/en/download.html
@@ -25,7 +25,7 @@
         <p>You can easily verufy that the image you downloaded is valid and authentic:</p>
         <ul>
             <li><strong>Download our public GPG key:</strong></li>
-            <p><code>gpg  --keyserver hkp://pgp.mit.edu --search-key 364B68D4</code></p>
+            <p><code>gpg --keyserver hkp://pgp.mit.edu --search-key 364B68D4</code></p>
                 
             <li><strong>Verifying the key fingerprint:</strong></li>
             <p><em>Make sure you downloaded a genuine copy of our GPG key</em></p>

--- a/templates/es/descargas.html
+++ b/templates/es/descargas.html
@@ -24,7 +24,7 @@
         <p>Puedes verificar la integridad y la autenticidad del fichero bajado en pocos simples pasos:</p>
         <ul>
             <li><strong>Descarga la nuestra llave GPG pública:</strong></li>
-            <p><code>gpg --keyserver pool.sks-keyservers.net --search-key 364B68D4</code></p>
+            <p><code>gpg --keyserver hkp://pgp.mit.edu --search-key 364B68D4</code></p>
                 
             <li><strong>Verifica el fingerprint de la llave:</strong></li>
             <p><em>Este paso es necesario para asegurarte que la llave GPG bajada es la nuestra</em></p>

--- a/templates/es/descargas.html
+++ b/templates/es/descargas.html
@@ -24,7 +24,7 @@
         <p>Puedes verificar la integridad y la autenticidad del fichero bajado en pocos simples pasos:</p>
         <ul>
             <li><strong>Descarga la nuestra llave GPG pública:</strong></li>
-            <p><code>gpg --search-key 364B68D4</code></p>
+            <p><code>gpg --keyserver pool.sks-keyservers.net --search-key 364B68D4</code></p>
                 
             <li><strong>Verifica el fingerprint de la llave:</strong></li>
             <p><em>Este paso es necesario para asegurarte que la llave GPG bajada es la nuestra</em></p>

--- a/templates/it/download.html
+++ b/templates/it/download.html
@@ -25,7 +25,7 @@
         <p>E' possibile verificare la validità e l'autenticità dell'immagine scaricata in pochi semplici passaggi:</p>
         <ul>
             <li><strong>Scarica la nostra chiave GPG pubblica:</strong></li>
-            <p><code>gpg --keyserver pool.sks-keyservers.net --search-key 364B68D4</code></p>
+            <p><code>gpg --keyserver hkp://pgp.mit.edu --search-key 364B68D4</code></p>
                 
             <li><strong>Verifica il fingerprint della chiave:</strong></li>
             <p><em>Questo passaggio e' necessario per assicurarti che la chiave gpg scaricata sia la nostra</em></p>

--- a/templates/it/download.html
+++ b/templates/it/download.html
@@ -25,7 +25,7 @@
         <p>E' possibile verificare la validità e l'autenticità dell'immagine scaricata in pochi semplici passaggi:</p>
         <ul>
             <li><strong>Scarica la nostra chiave GPG pubblica:</strong></li>
-            <p><code>gpg --search-key 364B68D4</code></p>
+            <p><code>gpg --keyserver pool.sks-keyservers.net --search-key 364B68D4</code></p>
                 
             <li><strong>Verifica il fingerprint della chiave:</strong></li>
             <p><em>Questo passaggio e' necessario per assicurarti che la chiave gpg scaricata sia la nostra</em></p>


### PR DESCRIPTION
at debian 7.0 I have this error running this command
$ gpg --search-key 364B68D4
gpg: no keyserver known (use option --keyserver)
gpg: keyserver search failed: bad URI

So I propose to add this key server hkp://pgp.mit.edu 
$ gpg  --keyserver hkp://pgp.mit.edu --search-key 364B68D4
added --keyserver param to gpg --search key
